### PR TITLE
resolved issue of being unable to return index of id no.1

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -71,7 +71,7 @@ export const deleteDbItemById = (id: number): DbItemWithId | "not found" => {
 const findIndexOfDbItemById = (id: number): number | "not found" => {
   const matchingIdx = db.findIndex((entry) => entry.id === id);
   // .findIndex returns -1 if not located
-  if (matchingIdx) {
+  if (matchingIdx !== -1) {
     return matchingIdx;
   } else {
     return "not found";


### PR DESCRIPTION
The index of the first id (id no. 1) was not being returned by the findIndexOfDbItemById function in db.ts file. This issue was resolved by updating line 74 from if (matchingIdx) to if (matchingIdx !== -1).